### PR TITLE
start-dfs and start-yarn now work as part of provisioning

### DIFF
--- a/ansible/playbooks/Vagrantfile
+++ b/ansible/playbooks/Vagrantfile
@@ -71,7 +71,7 @@ Vagrant.configure("2") do |config|
   # SHELL
 
   config.vm.provision "ansible" do |ansible|
-     ansible.playbook = "provision/oozie-playbook.yml"
+     ansible.playbook = "provision/hadoop-playbook.yml"
 
     # enable for debugging
     # ansible.verbose = "vvv"

--- a/ansible/playbooks/provision/roles/aervits.common/tasks/main.yml
+++ b/ansible/playbooks/provision/roles/aervits.common/tasks/main.yml
@@ -42,9 +42,18 @@
     line: vm.swapiness={{ vm_swapiness }}
     backup: yes
 
-# for expect module to work this is required but needs to be at least 3.3 version
-- name: get all required prerequisites
+# can this be consolidated? epel-release must come first, then python-pip
+- name: install epel-release for python-pip package
   package:
     name: "{{ item }}"
     state: latest
-  with_items: pexpect
+  with_items: epel-release
+
+- name: install python-pip for pexpect module as CentOS gets you pexpect <= 3.3
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items: python-pip
+
+- name: install pexpect from pip
+  shell: pip install pexpect

--- a/ansible/playbooks/provision/roles/aervits.hadoop/tasks/main.yml
+++ b/ansible/playbooks/provision/roles/aervits.hadoop/tasks/main.yml
@@ -133,13 +133,18 @@
 
 # fails due to pexpect module < 3.3 figure out how to install it and then uncomment start script
 
-#  - name: Generic question with multiple different responses
-#    expect:
-#      command: $HADOOP_PREFIX/sbin/start-dfs.sh
-#      responses:
-#        Question:
-#          - yes
-#          - yes
-#          - yes
+  - name: start namenode, datanode, secondarynamenode
+    expect:
+      command: /opt/hadoop/{{ hadoop_version }}/sbin/start-dfs.sh
+      responses:
+          'Are you sure you want to continue connecting \(yes/no\)?': 'yes'
+    become: true
+    become_user: hadoop
 
-#Are you sure you want to continue connecting (yes/no)?
+  - name: start resourcemanager, nodemanager
+    expect:
+      command: /opt/hadoop/{{ hadoop_version }}/sbin/start-yarn.sh
+      responses:
+          'Are you sure you want to continue connecting \(yes/no\)?': 'yes'
+    become: true
+    become_user: hadoop


### PR DESCRIPTION
if you check jps under hadoop user, you can see all required services are now running